### PR TITLE
Adding ability to set buffer on a pad probe info object

### DIFF
--- a/gst/gst.go.c
+++ b/gst/gst.go.c
@@ -171,9 +171,7 @@ GstSample * getSampleValue (GValue * val)
 
 void gstPadProbeInfoSetBuffer (GstPadProbeInfo * info, GstBuffer * buffer)
 {
-	if (buffer != NULL)
-        buffer = gst_buffer_ref (buffer);   // give the probe machinery its own ref
-    info->data = buffer;
+	info->data = buffer;
 }
 
 /* MpegtsSection Utilities */

--- a/gst/gst.go.c
+++ b/gst/gst.go.c
@@ -171,10 +171,9 @@ GstSample * getSampleValue (GValue * val)
 
 void gstPadProbeInfoSetBuffer (GstPadProbeInfo * info, GstBuffer * buffer)
 {
-	gst_mini_object_replace(
-		(GstMiniObject **)&info->data,
-		buffer ? GST_MINI_OBJECT_CAST(buffer) : NULL
-	);
+	if (buffer != NULL)
+        buffer = gst_buffer_ref (buffer);   // give the probe machinery its own ref
+    info->data = buffer;
 }
 
 /* MpegtsSection Utilities */

--- a/gst/gst.go.c
+++ b/gst/gst.go.c
@@ -167,6 +167,16 @@ GstSample * getSampleValue (GValue * val)
 	return gst_value_get_sample(val);
 }
 
+/* PadProbe utilities */
+
+void gstPadProbeInfoSetBuffer (GstPadProbeInfo * info, GstBuffer * buffer)
+{
+	gst_mini_object_replace(
+		(GstMiniObject **)&info->data,
+		buffer ? GST_MINI_OBJECT_CAST(buffer) : NULL
+	);
+}
+
 /* MpegtsSection Utilities */
 GstMpegtsSection *  mpegtsSectionRef    (GstMpegtsSection * section)    { return gst_mpegts_section_ref(section); }
 void                mpegtsSectionUnref  (GstMpegtsSection * section)    { gst_mpegts_section_unref(section); } 

--- a/gst/gst.go.h
+++ b/gst/gst.go.h
@@ -151,4 +151,8 @@ extern int sizeOfGCharArray (gchar ** arr);
 
 extern GstSample * getSampleValue (GValue * val);
 
+/* PadProbe utilities */
+
+extern void gstPadProbeInfoSetBuffer (GstPadProbeInfo * info, GstBuffer * buffer);
+
 #endif

--- a/gst/gst_pad.go
+++ b/gst/gst_pad.go
@@ -1125,11 +1125,11 @@ func (p *PadProbeInfo) GetBuffer() *Buffer {
 }
 
 func (p *PadProbeInfo) SetBuffer(buf *Buffer) {
-	var cBuf *C.GstBuffer
-	if buf != nil {
-		cBuf = buf.Instance()
+	if buf == nil {
+		C.gstPadProbeInfoSetBuffer(p.ptr, nil)
+		return
 	}
-	C.gstPadProbeInfoSetBuffer(p.ptr, cBuf)
+	C.gstPadProbeInfoSetBuffer(p.ptr, buf.Ref().Instance())
 }
 
 // GetBufferList returns the buffer list, if any, inside this probe info.

--- a/gst/gst_pad.go
+++ b/gst/gst_pad.go
@@ -1124,6 +1124,14 @@ func (p *PadProbeInfo) GetBuffer() *Buffer {
 	return wrapBuffer(buf)
 }
 
+func (p *PadProbeInfo) SetBuffer(buf *Buffer) {
+	var cBuf *C.GstBuffer
+	if buf != nil {
+		cBuf = buf.Instance()
+	}
+	C.gstPadProbeInfoSetBuffer(p.ptr, cBuf)
+}
+
 // GetBufferList returns the buffer list, if any, inside this probe info.
 func (p *PadProbeInfo) GetBufferList() *BufferList {
 	bufList := C.gst_pad_probe_info_get_buffer_list(p.ptr)


### PR DESCRIPTION
This is needed when a pad probe wants to modify e.g buffer's data (metadata) and buffer is marked as read-only. The existing API exposes a function to make the buffer writable which is needed but doesn't expose an API to replace the readonly buffer with the writable one in the pad probe info object.